### PR TITLE
Fixed tsconfig files

### DIFF
--- a/office-add-in/tsconfig.json
+++ b/office-add-in/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../tsconfig.json"
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["office-js", "node"],
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "sourceMap": true,
     "target": "es5",
     "lib": ["dom", "es2015"],
-    "types": ["office-js", "node"],
+    "types": ["node"],
     "strict": true,
     "pretty": true,
     "typeRoots": ["node_modules/@types"]


### PR DESCRIPTION
Fixed the referencing of tsconfig files. In the backend `office-js` used to be referenced through the `tsconfig.json` files. This is now moved to purely work in the frontend

Solves PZ-7299