### PR TITLE
feat: Allow setting paths to pki files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@
 
 JWT_SECRET=SECRECT_KEY_PLACEHOLDER
 API_BASE_URL=http://localhost:8020
+KEY_PATH=./key.pem
+CERT_PATH=./cert.pem
+CA_CERT_PATH=./ca-cert.pem

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -33,4 +33,5 @@ header:
     - "**/manifest.xml"
     - "**/*.example.cnf"
     - ".hintrc"
+    - "**/entrypoint.sh"
   comment: on-failure

--- a/charts/office-add-in/Chart.yaml
+++ b/charts/office-add-in/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: podiumd-office-plugin
 description: A Helm chart for deploying the podiumd-office-plugin (frontend and backend)
 type: application
-version: 0.0.3
+version: 0.0.4
 appVersion: 0.0.70

--- a/charts/office-add-in/README.md
+++ b/charts/office-add-in/README.md
@@ -31,8 +31,8 @@ The Github workflow will perform helm-linting and will bump the version if neede
 |-----|------|---------|-------------|
 | backend.apiBaseUrl | string | `"http://localhost:8020"` | Base URL to the openzaak API |
 | backend.certificate.caPath | string | `""` | path to ca certificate file. If not specified, a self signed certificate will be generated for localhost |
-| backend.certificate.certPath | string | `""` | path to certificate file |
-| backend.certificate.keyPath | string | `""` | path to private key file |
+| backend.certificate.certPath | string | `""` | path to certificate file. If not specified, a self signed certificate will be generated for localhost |
+| backend.certificate.keyPath | string | `""` | path to private key file. If not specified, a self signed certificate will be generated for localhost |
 | backend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | backend.image.repository | string | `"ghcr.io/infonl/podiumd-office-add-in-backend"` |  |
 | backend.image.tag | string | `"latest"` |  |

--- a/charts/office-add-in/README.md
+++ b/charts/office-add-in/README.md
@@ -1,6 +1,6 @@
 # podiumd-office-plugin
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.70](https://img.shields.io/badge/AppVersion-0.0.70-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.70](https://img.shields.io/badge/AppVersion-0.0.70-informational?style=flat-square)
 
 A Helm chart for deploying the podiumd-office-plugin (frontend and backend)
 
@@ -29,7 +29,10 @@ The Github workflow will perform helm-linting and will bump the version if neede
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| backend.apiBaseUrl | string | `"http://localhost:8020"` | Base URL for the backend API to connect to external services |
+| backend.apiBaseUrl | string | `"http://localhost:8020"` | Base URL to the openzaak API |
+| backend.certificate.caPath | string | `""` | path to ca certificate file |
+| backend.certificate.certPath | string | `""` | path to certificate file |
+| backend.certificate.keyPath | string | `""` | path to private key file |
 | backend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | backend.image.repository | string | `"ghcr.io/infonl/podiumd-office-add-in-backend"` |  |
 | backend.image.tag | string | `"latest"` |  |

--- a/charts/office-add-in/README.md
+++ b/charts/office-add-in/README.md
@@ -30,7 +30,7 @@ The Github workflow will perform helm-linting and will bump the version if neede
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | backend.apiBaseUrl | string | `"http://localhost:8020"` | Base URL to the openzaak API |
-| backend.certificate.caPath | string | `""` | path to ca certificate file |
+| backend.certificate.caPath | string | `""` | path to ca certificate file. If not specified, a self signed certificate will be generated for localhost |
 | backend.certificate.certPath | string | `""` | path to certificate file |
 | backend.certificate.keyPath | string | `""` | path to private key file |
 | backend.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/office-add-in/ci/helm-testing-values.yaml
+++ b/charts/office-add-in/ci/helm-testing-values.yaml
@@ -24,8 +24,8 @@ backend:
 
   certificate:
     # -- path to ca certificate file
-    caPath: ""
+    caPath: "./testca"
     # -- path to private key file
-    keyPath: ""
+    keyPath: "./testkey"
     # -- path to certificate file
-    certPath: ""
+    certPath: "./testcert"

--- a/charts/office-add-in/ci/helm-testing-values.yaml
+++ b/charts/office-add-in/ci/helm-testing-values.yaml
@@ -24,8 +24,8 @@ backend:
 
   certificate:
     # -- path to ca certificate file
-    caPath: "./testca"
+    caPath: ""
     # -- path to private key file
-    keyPath: "./testkey"
+    keyPath: ""
     # -- path to certificate file
-    certPath: "./testcert"
+    certPath: ""

--- a/charts/office-add-in/ci/helm-testing-values.yaml
+++ b/charts/office-add-in/ci/helm-testing-values.yaml
@@ -19,5 +19,13 @@ backend:
     port: 3003
   # -- Secret key used for generating and validating JWT tokens for secure communication
   jwtSecret: "SECRECT_KEY_PLACEHOLDER"
-  # -- Base URL for the backend API to connect to external services
+  # -- Base URL to the openzaak API
   apiBaseUrl: "http://localhost:8020"
+
+  certificate:
+    # -- path to ca certificate file
+    caPath: ""
+    # -- path to private key file
+    keyPath: ""
+    # -- path to certificate file
+    certPath: ""

--- a/charts/office-add-in/ci/helm-testing-values.yaml
+++ b/charts/office-add-in/ci/helm-testing-values.yaml
@@ -23,9 +23,9 @@ backend:
   apiBaseUrl: "http://localhost:8020"
 
   certificate:
-    # -- path to ca certificate file
+    # -- path to ca certificate file. If not specified, a self signed certificate will be generated for localhost
     caPath: ""
-    # -- path to private key file
+    # -- path to private key file. If not specified, a self signed certificate will be generated for localhost
     keyPath: ""
-    # -- path to certificate file
+    # -- path to certificate file. If not specified, a self signed certificate will be generated for localhost
     certPath: ""

--- a/charts/office-add-in/templates/backend-deployment.yaml
+++ b/charts/office-add-in/templates/backend-deployment.yaml
@@ -23,3 +23,11 @@ spec:
               value: {{ .Values.backend.jwtSecret | quote }}
             - name: API_BASE_URL
               value: {{ .Values.backend.apiBaseUrl | quote }}
+            - name: CA_CERT_PATH
+              value: {{ .Values.backend.certificate.caPath | default "./ca-cert.pem" | quote }}
+            - name: KEY_PATH
+              value: {{ .Values.backend.certificate.keyPath | default "./key.pem" | quote }}
+            - name: CERT_PATH
+              value: {{ .Values.backend.certificate.certPath | default "./cert.pem" | quote }}
+            - name: GENERATE_SELF_SIGNED
+              value: {{- if .Values.backend.certificate.certPath }}"false"{{- else }}"true" {{- end }}

--- a/charts/office-add-in/templates/backend-deployment.yaml
+++ b/charts/office-add-in/templates/backend-deployment.yaml
@@ -30,4 +30,4 @@ spec:
             - name: CERT_PATH
               value: {{ .Values.backend.certificate.certPath | default "./cert.pem" | quote }}
             - name: GENERATE_SELF_SIGNED
-              value: {{- if .Values.backend.certificate.certPath }}"false"{{- else }}"true" {{- end }}
+              value: {{ if .Values.backend.certificate.certPath }}"false"{{ else }}"true"{{ end }}

--- a/charts/office-add-in/values.yaml
+++ b/charts/office-add-in/values.yaml
@@ -19,5 +19,13 @@ backend:
     port: 3003
   # -- Secret key used for generating and validating JWT tokens for secure communication
   jwtSecret: "SECRECT_KEY_PLACEHOLDER"
-  # -- Base URL for the backend API to connect to external services
+  # -- Base URL to the openzaak API
   apiBaseUrl: "http://localhost:8020"
+
+  certificate:
+    # -- path to ca certificate file
+    caPath: ""
+    # -- path to private key file
+    keyPath: ""
+    # -- path to certificate file
+    certPath: ""

--- a/charts/office-add-in/values.yaml
+++ b/charts/office-add-in/values.yaml
@@ -25,7 +25,7 @@ backend:
   certificate:
     # -- path to ca certificate file. If not specified, a self signed certificate will be generated for localhost
     caPath: ""
-    # -- path to private key file
+    # -- path to private key file. If not specified, a self signed certificate will be generated for localhost
     keyPath: ""
-    # -- path to certificate file
+    # -- path to certificate file. If not specified, a self signed certificate will be generated for localhost
     certPath: ""

--- a/charts/office-add-in/values.yaml
+++ b/charts/office-add-in/values.yaml
@@ -23,7 +23,7 @@ backend:
   apiBaseUrl: "http://localhost:8020"
 
   certificate:
-    # -- path to ca certificate file
+    # -- path to ca certificate file. If not specified, a self signed certificate will be generated for localhost
     caPath: ""
     # -- path to private key file
     keyPath: ""

--- a/office-backend/Dockerfile
+++ b/office-backend/Dockerfile
@@ -18,9 +18,10 @@ RUN npm run types
 WORKDIR /app/office-backend
 
 RUN npm run build
+RUN chmod +x entrypoint.sh
 
 # Expose ports
 EXPOSE 3003
 
 # Set the entry point to the startup script
-ENTRYPOINT ["node", "dist/office-backend/src/app.js"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/office-backend/entrypoint.sh
+++ b/office-backend/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+# Check if GENERATE_SELF_SIGNED environment variable is set to true
+if [ "$GENERATE_SELF_SIGNED" = "true" ]; then
+  echo "Generating self-signed keys..."
+  ./generate-keys.sh
+fi
+
+# Start the Node.js application
+echo "Starting the Node.js application..."
+node dist/office-backend/src/app.js

--- a/office-backend/src/app.ts
+++ b/office-backend/src/app.ts
@@ -18,9 +18,9 @@ import { LoggerService } from "../service/LoggerService";
 
 const fastify = Fastify({
   https: {
-    key: fs.readFileSync("./key.pem"),
-    cert: fs.readFileSync("./cert.pem"),
-    ca: fs.readFileSync("./ca-cert.pem"),
+    key: fs.readFileSync(process.env.KEY_PATH!),
+    cert: fs.readFileSync(process.env.CERT_PATH!),
+    ca: fs.readFileSync(process.env.CA_CERT_PATH!),
   },
 });
 


### PR DESCRIPTION
* do not hardcode the paths to the certificate. Allows for easier volume-mounting
* If not set, run the `./generate-keys.sh` script during image startup to generate a self signed certificate for localhost

Solves PZ-7334